### PR TITLE
Replace squeeze w/ squish

### DIFF
--- a/lib/portable_text/plain/serializer.rb
+++ b/lib/portable_text/plain/serializer.rb
@@ -15,7 +15,7 @@ module PortableText
         nodes.map do |block|
           case block.type
           when "block"
-            block.children.map(&:text).join(" ").squeeze.strip
+            block.children.map(&:text).join(" ").squish
           when "list"
             visit(block.items)
           when "image"

--- a/test/fixtures/body.json
+++ b/test/fixtures/body.json
@@ -134,7 +134,7 @@
           "_key": "3b5016890b16",
           "_type": "span",
           "marks": [],
-          "text": "Texte avec les mots "
+          "text": "Texte avec les mots comme pomme de terre "
         },
         {
           "_key": "03b232374034",

--- a/test/plain/serializer_test.rb
+++ b/test/plain/serializer_test.rb
@@ -16,7 +16,7 @@ class PortableText::Plain::SerializerTest < Minitest::Test
         Citation
         Texte avec le mot gras en gras
         Texte avec le mot italique en italique
-        Texte avec les mots gras italique en gras et italique
+        Texte avec les mots comme pomme de terre gras italique en gras et italique
         liste level 1
         liste level 1
         liste level 1

--- a/test/serializer_test.rb
+++ b/test/serializer_test.rb
@@ -131,7 +131,7 @@ class SerializerTest < Minitest::Test
     content = render PortableText::Serializer.new(content: body["body"]).render
     assert_equal(
       content,
-      "<h1>Titre h1</h1><h2>Titre h2</h2><h3>Titre h3</h3><h4>Titre h4</h4><blockquote>Citation</blockquote><p>Texte avec le mot <strong>gras</strong> en gras</p><p>Texte avec le mot <em>italique</em> en italique</p><p>Texte avec les mots <strong><em>gras italique</em></strong> en gras et italique</p><ul><li>liste level 1</li><li>liste level 1</li><li>liste level 1</li><ul><li>sous liste level 2</li></ul><ul><li>sous liste <strong>level 2</strong></li><ul><li>sous liste <em>level 3</em></li></ul></ul><ul><li>sous liste level 2</li></ul><li>liste level 1</li><ul><li>sous liste level 2</li><ul><li>sous liste level 3</li></ul></ul><ul><li>sous liste level 2</li></ul></ul><p><a href=\"http://www.sanity.io\">Lien externe</a>  </p>"
+      "<h1>Titre h1</h1><h2>Titre h2</h2><h3>Titre h3</h3><h4>Titre h4</h4><blockquote>Citation</blockquote><p>Texte avec le mot <strong>gras</strong> en gras</p><p>Texte avec le mot <em>italique</em> en italique</p><p>Texte avec les mots comme pomme de terre <strong><em>gras italique</em></strong> en gras et italique</p><ul><li>liste level 1</li><li>liste level 1</li><li>liste level 1</li><ul><li>sous liste level 2</li></ul><ul><li>sous liste <strong>level 2</strong></li><ul><li>sous liste <em>level 3</em></li></ul></ul><ul><li>sous liste level 2</li></ul><li>liste level 1</li><ul><li>sous liste level 2</li><ul><li>sous liste level 3</li></ul></ul><ul><li>sous liste level 2</li></ul></ul><p><a href=\"http://www.sanity.io\">Lien externe</a>  </p>"
     )
   end
   # rubocop:enable Layout/LineLength


### PR DESCRIPTION
There's an issue when using the plain serializer. The `squeeze` method will remove any duplicate characters. 

```
"comme pomme de terre".squeeze
# =>"come pome de tere"
```

I have update this to use the `squish` method instead. From the [docs](https://apidock.com/rails/String/squish):

> Returns the string, [first](https://apidock.com/rails/String/first) removing all whitespace on both ends of the string, and then changing remaining consecutive whitespace groups into one space each.